### PR TITLE
Evaluate env vars at call time in DbContextEnvironmentFactory

### DIFF
--- a/src/ConfiguredSqlConnection.Abstractions/Extensions/DbContextEnvironmentFactory.cs
+++ b/src/ConfiguredSqlConnection.Abstractions/Extensions/DbContextEnvironmentFactory.cs
@@ -7,9 +7,11 @@ public class DbContextEnvironmentFactory<TContext>(DbContextOptionsBuilderFactor
     : DbContextFactory<TContext>(optionsBuilderFactory)
     where TContext : DbContext
 {
-    private readonly ContextOption dbMode = EnvManager.Get<ContextOption>("CONFIGUREDSQLCONNECTION_DB_MODE", true);
-    private readonly string dbName = EnvManager.Get<string>("CONFIGUREDSQLCONNECTION_DB_NAME");
+    public virtual TContext CreateFromEnvironment()
+    {
+        var dbMode = EnvManager.Get<ContextOption>("CONFIGUREDSQLCONNECTION_DB_MODE", true);
+        var dbName = EnvManager.Get<string>("CONFIGUREDSQLCONNECTION_DB_NAME");
 
-    public virtual TContext CreateFromEnvironment() =>
-        Create(dbMode, dbName);
+        return Create(dbMode, dbName);
+    }
 }

--- a/src/ConfiguredSqlConnection.Abstractions/Extensions/DbContextEnvironmentFactory.cs
+++ b/src/ConfiguredSqlConnection.Abstractions/Extensions/DbContextEnvironmentFactory.cs
@@ -9,9 +9,8 @@ public class DbContextEnvironmentFactory<TContext>(DbContextOptionsBuilderFactor
 {
     public virtual TContext CreateFromEnvironment()
     {
-        var dbMode = EnvManager.Get<ContextOption>("CONFIGUREDSQLCONNECTION_DB_MODE", true);
+        var dbMode = EnvManager.GetRequired<ContextOption>("CONFIGUREDSQLCONNECTION_DB_MODE");
         var dbName = EnvManager.Get<string>("CONFIGUREDSQLCONNECTION_DB_NAME");
-
         return Create(dbMode, dbName);
     }
 }

--- a/tests/ConfiguredSqlConnection.Abstractions.Tests/Extensions/FactoriesTests.cs
+++ b/tests/ConfiguredSqlConnection.Abstractions.Tests/Extensions/FactoriesTests.cs
@@ -1,6 +1,5 @@
 using Moq;
 using Xunit;
-using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using ConfiguredSqlConnection.Abstractions.Extensions;
 
@@ -55,9 +54,9 @@ public class FactoriesTests
         factory.Setup(x => x.Create(contextOption, null)).CallBase();
         factory.Setup(x => x.CreateFromEnvironment()).CallBase();
 
-        var exception = Assert.Throws<TargetInvocationException>(() => factory.Object.CreateFromEnvironment());
+        var exception = Assert.Throws<ArgumentNullException>(factory.Object.CreateFromEnvironment);
 
-        Assert.Equal(expectedExceptionMessage, exception.InnerException?.Message);
+        Assert.Equal(expectedExceptionMessage, exception.Message);
     }
 
     [Fact]
@@ -66,14 +65,13 @@ public class FactoriesTests
         var invalidOption = "Production";
         var expectedExceptionMessage = $"Failed to convert environment variable 'CONFIGUREDSQLCONNECTION_DB_MODE' to type '{typeof(ContextOption).FullName}'.";
         Environment.SetEnvironmentVariable("CONFIGUREDSQLCONNECTION_DB_MODE", $"{invalidOption}");
-        Environment.SetEnvironmentVariable("CONFIGUREDSQLCONNECTION_DB_NAME", $"");
+        Environment.SetEnvironmentVariable("CONFIGUREDSQLCONNECTION_DB_NAME", "");
         var factory = new Mock<DbContextEnvironmentFactory<DbContext>>(optionsBuilderFactory);
         factory.Setup(x => x.Create(contextOption, null)).CallBase();
         factory.Setup(x => x.CreateFromEnvironment()).CallBase();
 
-        var exception = Assert.Throws<TargetInvocationException>(() => factory.Object.CreateFromEnvironment());
+        var exception = Assert.Throws<InvalidCastException>(factory.Object.CreateFromEnvironment);
 
-        Assert.NotNull(exception.InnerException);
-        Assert.Equal(expectedExceptionMessage, exception.InnerException.Message);
+        Assert.Equal(expectedExceptionMessage, exception.Message);
     }
 }


### PR DESCRIPTION
## Summary
- evaluate environment variables when creating DbContext from environment

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ea607194832a821d0e2a22a02342